### PR TITLE
fix(pack): add checkout blocks to pack script

### DIFF
--- a/pack.sh
+++ b/pack.sh
@@ -26,6 +26,7 @@ if [ $1 != "prod" ]
       includes/class-wc-openpix-pix.php \
       includes/class-wc-openpix-pix-parcelado.php \
       includes/class-wc-openpix-pix-crediary.php \
+      includes/class-wc-openpix-pix-block.php \
       includes/customer/class-wc-openpix-customer.php \
       includes/config/config.php \
       languages \


### PR DESCRIPTION
Pix checkout block file is not included when running `yarn pack:prod`:

![image](https://github.com/Open-Pix/woocommerce-openpix/assets/96352451/9c7b4d90-d331-4e7e-b579-288e0b4a865d)
