### PR TITLE
feat(charge) add return_existing param to prevent error on creating charge with same correlationID

### DIFF
--- a/includes/class-wc-openpix-pix.php
+++ b/includes/class-wc-openpix-pix.php
@@ -1107,6 +1107,9 @@ class WC_OpenPix_Pix_Gateway extends WC_Payment_Gateway
 
         $order->save();
 
+        $url = add_query_arg('return_existing', 'true', $url);
+        WC_OpenPix::debugJson('Charge post URL:', $url);
+
         $params = [
             'timeout' => 120,
             'headers' => [


### PR DESCRIPTION
Using API to prevent error on using the same correlationID to create openPix charge

https://developers.openpix.com.br/en/api#tag/charge/paths/~1api~1v1~1charge/get

added log to validate the fix

```log
2025-02-27T14:45:10+00:00 DEBUG Charge post URL:
"https://api.openpix.com.br/api/v1/charge?return_existing=true"
2025-02-27T14:45:10+00:00 DEBUG Charge post payload:
{
    "correlationID": "wc_order_xWPZqw27sJHs3-119",
    "value": 2000,
    "comment": "wordpress dev#119",
    "additionalInfo": [
        {
            "key": "Order",
            "value": 119
        }
    ],
    "customer": {
        "name": "dev elopers",
        "email": "developers@woovi.com",
        "taxID": "",
        "phone": 55
    }
}
```