### PR TITLE
fix remove syntax php 8 to support php 7.4

### DIFF
--- a/woocommerce-openpix.php
+++ b/woocommerce-openpix.php
@@ -288,9 +288,7 @@ function checkCompabilityCheckoutBlock()
     return is_plugin_active($pluginId) &&
         class_exists('Automattic\WooCommerce\Blocks\Package') &&
         file_exists(
-            filename: __DIR__ .
-                '/assets/' .
-                WC_OpenPix_Pix_Block::PIX_BLOCK_SCRIPT_FILENAME
+            __DIR__ .  '/assets/' . WC_OpenPix_Pix_Block::PIX_BLOCK_SCRIPT_FILENAME
         );
 }
 


### PR DESCRIPTION
```sh
2025-02-27T18:33:43+00:00 CRITICAL syntax error, unexpected ':', expecting ')' CONTEXT: {"error":{"type":4,"file":"/var/www/html/wp-content/plugins/openpix-for-woocommerce/woocommerce-openpix.php","line":291},"remote-logging":true,"backtrace":[{"file":"/var/www/html/wp-content/plugins/woocommerce/includes/class-woocommerce.php","line":414,"function":"critical","class":"WC_Logger","type":"->"},{"function":"log_errors","class":"WooCommerce","type":"->"}]}
```

https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments