### PR TITLE
build(change-log): v2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+#### 2.12.1 (2025-03-05)
+
+##### Build System / Dependencies
+
+* **change-log:**
+  *  v2.12.0 (#1409) (02be24e6)
+  *  v2.11.0 (#1404) (920b012e)
+  *  v2.10.10 (#1400) (3a2c5a8b)
+
+##### New Features
+
+* **update:**
+  *  update tested up to (#1405) (9b453d69)
+  *  update the readme.txt (e5517bdd)
+* **correlationID:**  save correlationID before of all (#1403) (4bf599a9)
+* **timeout:**
+  *  update timeout of request (#1402) (658cd1d4)
+  *  update timeout of request (f37f7bf7)
+* **release:**  v2.10.9 (#1398) (979c0cd3)
+* **pix:**  add email hook (#1397) (2febc373)
+
+##### Bug Fixes
+
+*  remove named arguments php8 (#1413) (5dbf61ce)
+* **pack:**  add checkout blocks to pack script (#1399) (a536a55d)
+* **checkout:**
+  *  show gateway description (#1396) (acbe5ee8)
+  *  add checkout blocks compatibility for pix (#1395) (9ad16297)
+* **features:**  declare compability with checkout blocks (#1394) (5e9710be)
+
+##### Other Changes
+
+* //github.com/Open-Pix/woocommerce-openpix (1d8dd637)
+
 #### 2.12.0 (2025-02-19)
 
 ##### Build System / Dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-openpix",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-proposal-export-default-from": "7.23.3",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, openpix, payment
 Requires at least: 4.0
 Tested up to: 9.4.0
 Requires PHP: 7.3
-Stable tag: 2.12.0
+Stable tag: 2.12.1
 License: GPLv2 or later
 License URI: <http://www.gnu.org/licenses/gpl-2.0.html>
 

--- a/woocommerce-openpix.php
+++ b/woocommerce-openpix.php
@@ -5,7 +5,7 @@
  * Description: Aceite pagamentos Pix em com atualização em tempo real, checkout transparente e atualização automática de status do pedido.
  * Author: OpenPix
  * Author URI: https://openpix.com.br/
- * Version: 2.12.0
+ * Version: 2.12.1
  * Text Domain: woocommerce-openpix
  * WC tested up to: 8.2.2
  * Requires Plugins: woocommerce
@@ -55,7 +55,7 @@ function woocommerce_openpix_init()
 
 class WC_OpenPix
 {
-    const VERSION = '2.12.0';
+    const VERSION = '2.12.1';
 
     protected static $instance = null;
 


### PR DESCRIPTION
v2.12.1

![image](https://github.com/user-attachments/assets/7259cfeb-dd5f-462e-892e-9c136a30cea0)
